### PR TITLE
Cheek sorting has been implemented on both client and server side.

### DIFF
--- a/client/cheekstash-client/src/app/cheeks/cheek-list/cheek-list.component.html
+++ b/client/cheekstash-client/src/app/cheeks/cheek-list/cheek-list.component.html
@@ -24,10 +24,11 @@
                 (change)="onSortChange($event)" 
                 [ngModel]="currentSortBy">
             <option value="recent">Most Recent</option>
-            <option value="rating-desc">Rating: High to Low</option>
-            <option value="rating-asc">Rating: Low to High</option>
-            <option value="alpha-asc">Alphabetical: A to Z</option>
-            <option value="alpha-desc">Alphabetical: Z to A</option>
+            <option value="oldest">Oldest</option>
+            <option value="rating">Rating: High to Low</option>
+            <option value="reviewCount">Most Reviewed</option>
+            <option value="alpha">Alphabetical: A to Z</option>
+            <option value="alphaDesc">Alphabetical: Z to A</option>
         </select>
     </div>
 
@@ -129,17 +130,17 @@
                 <!-- End Average Rating Display -->
 
                 <div class="text-xs text-base-content/60 mb-3 space-y-1">
-                    <div *ngIf="cheek.categoryId">
+                    <div *ngIf="getCategoryName(cheek); else noCategory">
                         <strong>Category:</strong>
-                        <a [routerLink]="['/cheeks']" [queryParams]="{ categoryNames: [cheek.categoryId.name] }"
+                        <a [routerLink]="['/cheeks']" [queryParams]="{ categoryNames: [getCategoryName(cheek)] }"
                            class="badge badge-outline badge-sm ml-1 link link-hover">
-                           {{ cheek.categoryId.name }}
+                           {{ getCategoryName(cheek) }}
                         </a>
                     </div>
-                    <div *ngIf="!cheek.categoryId">
+                    <ng-template #noCategory>
                         <strong>Category:</strong>
                         <span class="badge badge-outline badge-sm ml-1 text-base-content/50">N/A</span>
-                    </div>
+                    </ng-template>
                     <div>
                         <strong>User:</strong>
                         <ng-container *ngIf="isUser(cheek.owner)">
@@ -147,8 +148,7 @@
                         </ng-container>
                         <ng-container *ngIf="!isUser(cheek.owner) && cheek.owner">
                             <span class="font-medium ml-1 text-error italic">
-                                Owner ID: {{cheek.owner}}
-                                (User data not fully loaded)
+                                Owner ID: {{cheek.owner}} (User data not fully loaded)
                             </span>
                         </ng-container>
                         <ng-container *ngIf="!cheek.owner">
@@ -163,18 +163,18 @@
                             </span>
                         </div>
                     </ng-container>
-                    <div *ngIf="cheek.tagIds && cheek.tagIds.length > 0">
+                    <div *ngIf="getTagNames(cheek).length > 0; else noTags">
                         <strong>Tags:</strong>
-                        <span *ngFor="let tag of cheek.tagIds" class="badge badge-ghost badge-sm ml-1">
-                            <a [routerLink]="['/cheeks']" [queryParams]="{ tagNames: [tag.name] }" class="link link-hover">
-                                {{ tag.name }}
+                        <span *ngFor="let tagName of getTagNames(cheek)" class="badge badge-ghost badge-sm ml-1">
+                            <a [routerLink]="['/cheeks']" [queryParams]="{ tagNames: [tagName] }" class="link link-hover">
+                                {{ tagName }}
                             </a>
                         </span>
                     </div>
-                    <div *ngIf="(!cheek.tagIds || cheek.tagIds.length === 0)">
+                    <ng-template #noTags>
                         <strong>Tags:</strong>
                         <span class="badge badge-ghost badge-sm ml-1 text-base-content/50">None</span>
-                    </div>
+                    </ng-template>
                 </div>
 
                 <div class="card-actions justify-end items-center">

--- a/client/cheekstash-client/src/app/cheeks/cheek-list/cheek-list.component.ts
+++ b/client/cheekstash-client/src/app/cheeks/cheek-list/cheek-list.component.ts
@@ -33,7 +33,7 @@ export class CheekListComponent implements OnInit, OnDestroy {
   noCheeksFound: boolean = false;
 
   initialSearchFilters: InitialSearchFilters = {};
-  currentSortBy: string = 'recent';
+  currentSortBy: 'recent' | 'oldest' | 'rating' | 'reviewCount' | 'alpha' | 'alphaDesc' = 'recent';
 
   // Pagination state
   currentPage: number = 1;
@@ -83,7 +83,7 @@ export class CheekListComponent implements OnInit, OnDestroy {
     ).subscribe(({ filters, sortBy }) => {
       // Update properties that are @Input to CheekSearchComponent or used for sorting
       this.initialSearchFilters = filters; 
-      this.currentSortBy = sortBy;
+      this.currentSortBy = sortBy as 'recent' | 'oldest' | 'rating' | 'reviewCount' | 'alpha' | 'alphaDesc';
     });
   }
 
@@ -149,6 +149,7 @@ export class CheekListComponent implements OnInit, OnDestroy {
       tagIds: criteria.tagIds,
       page: pageToRequest,
       limit: limitToRequest,
+      sortBy: this.currentSortBy
     };
 
     this.cheeksService.getAllCheeksPaginated(serviceParams).pipe(
@@ -251,7 +252,7 @@ export class CheekListComponent implements OnInit, OnDestroy {
   }
 
   onSortChange(event: Event): void {
-    const newSortBy = (event.target as HTMLSelectElement).value;
+    const newSortBy = (event.target as HTMLSelectElement).value as 'recent' | 'oldest' | 'rating' | 'reviewCount' | 'alpha' | 'alphaDesc';
     if (this.currentSortBy === newSortBy) {
       return;
     }
@@ -271,42 +272,27 @@ export class CheekListComponent implements OnInit, OnDestroy {
       replaceUrl: true
     });
 
-    this.applyClientSideSorting();
+    if (this.currentSearchCriteria) {
+      this.cheeks = [];
+      this.allCheeksLoaded = false;
+      this.totalCheeksFromServer = 0;
+      this.currentPage = 1;
+      this.loadCheeks(this.currentSearchCriteria, true);
+    }
   }
 
-  applyClientSideSorting(): void {
-    if (!this.cheeks || this.cheeks.length === 0) {
-      return;
-    }
+  // Utility: Get category name from cheek (handles object structure)
+  getCategoryName(cheek: Cheek): string {
+    return cheek.categoryId && typeof cheek.categoryId === 'object' && 'name' in cheek.categoryId
+      ? cheek.categoryId.name
+      : '';
+  }
 
-    const sortedCheeks = [...this.cheeks];
-
-    const fallbackDateA = new Date(0); // Very old date
-
-    switch (this.currentSortBy) {
-      case 'recent':
-        sortedCheeks.sort((a, b) =>
-          new Date(b.createdAt || fallbackDateA).getTime() - new Date(a.createdAt || fallbackDateA).getTime()
-        );
-        break;
-      case 'rating-desc':
-        sortedCheeks.sort((a, b) => (b.averageRating ?? 0) - (a.averageRating ?? 0));
-        break;
-      case 'rating-asc':
-        sortedCheeks.sort((a, b) => (a.averageRating ?? 0) - (b.averageRating ?? 0));
-        break;
-      case 'alpha-asc':
-        sortedCheeks.sort((a, b) => a.title.localeCompare(b.title));
-        break;
-      case 'alpha-desc':
-        sortedCheeks.sort((a, b) => b.title.localeCompare(a.title));
-        break;
-      default:
-        // Default to recent if sortBy is unknown
-        sortedCheeks.sort((a, b) =>
-          new Date(b.createdAt || fallbackDateA).getTime() - new Date(a.createdAt || fallbackDateA).getTime()
-        );
-    }
-    this.cheeks = sortedCheeks;
+  // Utility: Get tag names from cheek (handles array of objects)
+  getTagNames(cheek: Cheek): string[] {
+    if (!cheek.tagIds || !Array.isArray(cheek.tagIds)) return [];
+    return cheek.tagIds
+      .filter(tag => tag && typeof tag === 'object' && 'name' in tag)
+      .map(tag => tag.name as string);
   }
 }

--- a/client/cheekstash-client/src/app/cheeks/cheeks.service.ts
+++ b/client/cheekstash-client/src/app/cheeks/cheeks.service.ts
@@ -29,6 +29,9 @@ export class CheeksService {
     if (params.limit) {
       httpParams = httpParams.set('limit', params.limit.toString());
     }
+    if (params.sortBy) {
+      httpParams = httpParams.set('sortBy', params.sortBy);
+    }
 
     return this.http.get<PaginatedCheeksResponse>(this.apiUrl, { params: httpParams });
   }

--- a/client/cheekstash-client/src/app/models/cheek.model.ts
+++ b/client/cheekstash-client/src/app/models/cheek.model.ts
@@ -57,6 +57,7 @@ export interface CheekQueryParams {
     tagNames?: string[];
     page?: number;
     limit?: number; 
+    sortBy?: 'recent' | 'oldest' | 'rating' | 'reviewCount' | 'alpha' | 'alphaDesc';
 }
 
 export interface PaginatedCheeksResponse {

--- a/server/cheekstash-server/src/cheeks/cheeks.service.spec.ts
+++ b/server/cheekstash-server/src/cheeks/cheeks.service.spec.ts
@@ -269,4 +269,143 @@ describe('CheeksService', () => {
             await expect(service.deleteCheeks(id, ownerId)).rejects.toThrow(NotFoundException);
         });
     });
+
+    describe('getCheeksPaginated', () => {
+        beforeEach(() => {
+            CheeksModel.find.mockReset();
+            CheeksModel.countDocuments.mockReset();
+        });
+        it('should call find and countDocuments with correct query and sort (default)', async () => {
+            CheeksModel.find.mockReturnValue({
+                select: jest.fn().mockReturnThis(),
+                populate: jest.fn().mockReturnThis(),
+                sort: jest.fn().mockReturnThis(),
+                skip: jest.fn().mockReturnThis(),
+                limit: jest.fn().mockReturnThis(),
+                lean: jest.fn().mockReturnThis(),
+                exec: jest.fn().mockResolvedValue([{ _id: 'c1', title: 'A' }]),
+            });
+            CheeksModel.countDocuments.mockReturnValue({ exec: jest.fn().mockResolvedValue(1) });
+            const result = await service.getCheeksPaginated({});
+            expect(result.cheeks[0]._id).toBe('c1');
+            expect(result.totalItems).toBe(1);
+            expect(CheeksModel.find).toHaveBeenCalled();
+            expect(CheeksModel.countDocuments).toHaveBeenCalled();
+        });
+        it('should support sortBy: oldest', async () => {
+            const sortSpy = jest.fn().mockReturnThis();
+            CheeksModel.find.mockReturnValue({
+                select: jest.fn().mockReturnThis(),
+                populate: jest.fn().mockReturnThis(),
+                sort: sortSpy,
+                skip: jest.fn().mockReturnThis(),
+                limit: jest.fn().mockReturnThis(),
+                lean: jest.fn().mockReturnThis(),
+                exec: jest.fn().mockResolvedValue([{ _id: 'c2', title: 'B' }]),
+            });
+            CheeksModel.countDocuments.mockReturnValue({ exec: jest.fn().mockResolvedValue(1) });
+            await service.getCheeksPaginated({ sortBy: 'oldest' });
+            expect(sortSpy).toHaveBeenCalledWith({ createdAt: 1 });
+        });
+        it('should support sortBy: rating', async () => {
+            const sortSpy = jest.fn().mockReturnThis();
+            CheeksModel.find.mockReturnValue({
+                select: jest.fn().mockReturnThis(),
+                populate: jest.fn().mockReturnThis(),
+                sort: sortSpy,
+                skip: jest.fn().mockReturnThis(),
+                limit: jest.fn().mockReturnThis(),
+                lean: jest.fn().mockReturnThis(),
+                exec: jest.fn().mockResolvedValue([{ _id: 'c3', title: 'C' }]),
+            });
+            CheeksModel.countDocuments.mockReturnValue({ exec: jest.fn().mockResolvedValue(1) });
+            await service.getCheeksPaginated({ sortBy: 'rating' });
+            expect(sortSpy).toHaveBeenCalledWith({ averageRating: -1, createdAt: -1 });
+        });
+        it('should support sortBy: reviewCount', async () => {
+            const sortSpy = jest.fn().mockReturnThis();
+            CheeksModel.find.mockReturnValue({
+                select: jest.fn().mockReturnThis(),
+                populate: jest.fn().mockReturnThis(),
+                sort: sortSpy,
+                skip: jest.fn().mockReturnThis(),
+                limit: jest.fn().mockReturnThis(),
+                lean: jest.fn().mockReturnThis(),
+                exec: jest.fn().mockResolvedValue([{ _id: 'c4', title: 'D' }]),
+            });
+            CheeksModel.countDocuments.mockReturnValue({ exec: jest.fn().mockResolvedValue(1) });
+            await service.getCheeksPaginated({ sortBy: 'reviewCount' });
+            expect(sortSpy).toHaveBeenCalledWith({ reviewCount: -1, createdAt: -1 });
+        });
+        it('should support sortBy: alpha', async () => {
+            const sortSpy = jest.fn().mockReturnThis();
+            CheeksModel.find.mockReturnValue({
+                select: jest.fn().mockReturnThis(),
+                populate: jest.fn().mockReturnThis(),
+                sort: sortSpy,
+                skip: jest.fn().mockReturnThis(),
+                limit: jest.fn().mockReturnThis(),
+                lean: jest.fn().mockReturnThis(),
+                exec: jest.fn().mockResolvedValue([{ _id: 'c5', title: 'E' }]),
+            });
+            CheeksModel.countDocuments.mockReturnValue({ exec: jest.fn().mockResolvedValue(1) });
+            await service.getCheeksPaginated({ sortBy: 'alpha' });
+            expect(sortSpy).toHaveBeenCalledWith({ title: 1, createdAt: -1 });
+        });
+        it('should support sortBy: alphaDesc', async () => {
+            const sortSpy = jest.fn().mockReturnThis();
+            CheeksModel.find.mockReturnValue({
+                select: jest.fn().mockReturnThis(),
+                populate: jest.fn().mockReturnThis(),
+                sort: sortSpy,
+                skip: jest.fn().mockReturnThis(),
+                limit: jest.fn().mockReturnThis(),
+                lean: jest.fn().mockReturnThis(),
+                exec: jest.fn().mockResolvedValue([{ _id: 'c6', title: 'F' }]),
+            });
+            CheeksModel.countDocuments.mockReturnValue({ exec: jest.fn().mockResolvedValue(1) });
+            await service.getCheeksPaginated({ sortBy: 'alphaDesc' });
+            expect(sortSpy).toHaveBeenCalledWith({ title: -1, createdAt: -1 });
+        });
+        it('should support pagination', async () => {
+            const skipSpy = jest.fn().mockReturnThis();
+            const limitSpy = jest.fn().mockReturnThis();
+            CheeksModel.find.mockReturnValue({
+                select: jest.fn().mockReturnThis(),
+                populate: jest.fn().mockReturnThis(),
+                sort: jest.fn().mockReturnThis(),
+                skip: skipSpy,
+                limit: limitSpy,
+                lean: jest.fn().mockReturnThis(),
+                exec: jest.fn().mockResolvedValue([{ _id: 'c7', title: 'G' }]),
+            });
+            CheeksModel.countDocuments.mockReturnValue({ exec: jest.fn().mockResolvedValue(1) });
+            await service.getCheeksPaginated({ page: 2, limit: 5 });
+            expect(skipSpy).toHaveBeenCalledWith(5); // (page-1)*limit
+            expect(limitSpy).toHaveBeenCalledWith(5);
+        });
+        it('should support filtering by categoryIds and tagIds', async () => {
+            const findSpy = jest.fn().mockReturnThis();
+            CheeksModel.find.mockImplementation((query) => {
+                findSpy(query);
+                return {
+                    select: jest.fn().mockReturnThis(),
+                    populate: jest.fn().mockReturnThis(),
+                    sort: jest.fn().mockReturnThis(),
+                    skip: jest.fn().mockReturnThis(),
+                    limit: jest.fn().mockReturnThis(),
+                    lean: jest.fn().mockReturnThis(),
+                    exec: jest.fn().mockResolvedValue([{ _id: 'c8', title: 'H' }]),
+                };
+            });
+            CheeksModel.countDocuments.mockReturnValue({ exec: jest.fn().mockResolvedValue(1) });
+            const categoryId = '507f1f77bcf86cd799439011';
+            const tagId = '507f1f77bcf86cd799439012';
+            await service.getCheeksPaginated({ categoryIds: [categoryId], tagIds: [tagId] });
+            expect(findSpy).toHaveBeenCalledWith(expect.objectContaining({
+                categoryId: { $in: [expect.any(Object)] },
+                tagIds: { $in: [expect.any(Object)] },
+            }));
+        });
+    });
 });

--- a/server/cheekstash-server/src/cheeks/cheeks.service.ts
+++ b/server/cheekstash-server/src/cheeks/cheeks.service.ts
@@ -231,6 +231,11 @@ export class CheeksService {
 
     try {
       let savedCheek = await newCheeks.save();
+      if (tagIds && tagIds.length > 0) {
+        for (const tagId of tagIds) {
+          await this.tagsService.updateTagUsageCount(tagId.toString(), 1);
+        }
+      }
       savedCheek = await savedCheek.populate(this.cheekPopulationPaths);
       return savedCheek;
     } catch (error: any) {
@@ -245,9 +250,31 @@ export class CheeksService {
 
   // Renamed from getCheeks to getCheeksPaginated
   async getCheeksPaginated(queryDto?: QueryCheeksDto, requestingUserId?: string): Promise<{ cheeks: CheeksDocument[], totalItems: number }> {
-    const { searchKeyword, categoryIds, tagIds, page = 1, limit = 10 } = queryDto || {};
-    // this.logger.debug(`getCheeksPaginated - queryDto: ${JSON.stringify(queryDto)}`); // Log DTO
+    const { page = 1, limit = 10 } = queryDto || {};
+    const query = this._buildCheeksQuery(queryDto, requestingUserId);
+    const sortOptions = this._buildCheeksSortOptions(queryDto?.sortBy);
+    const skip = (page - 1) * limit;
 
+    const [cheeksResults, totalItems] = await Promise.all([
+      this.CheeksModel.find(query)
+        .select('-links')
+        .populate(this.cheekListPopulationPaths)
+        .sort(sortOptions)
+        .skip(skip)
+        .limit(limit)
+        .lean()
+        .exec(),
+      this.CheeksModel.countDocuments(query).exec(),
+    ]);
+
+    return { cheeks: cheeksResults as CheeksDocument[], totalItems };
+  }
+
+  /**
+   * Build the MongoDB query for cheeks based on filters and search.
+   */
+  private _buildCheeksQuery(queryDto?: QueryCheeksDto, requestingUserId?: string): FilterQuery<CheeksDocument> {
+    const { searchKeyword, categoryIds, tagIds } = queryDto || {};
     const query: FilterQuery<CheeksDocument> = {};
     const filterConditions: FilterQuery<CheeksDocument>[] = [];
 
@@ -259,64 +286,67 @@ export class CheeksService {
       query.tagIds = { $in: tagIds.map(id => new Types.ObjectId(id)) };
     }
 
-    // Visibility conditions
-    const visibilityQueryPart: FilterQuery<CheeksDocument> = {};
-    if (requestingUserId) {
-      visibilityQueryPart.$or = [
-        { isPublic: true },
-        { owner: new Types.ObjectId(requestingUserId) },
-      ];
-    } else {
-      visibilityQueryPart.isPublic = true;
-    }
-    filterConditions.push(visibilityQueryPart);
+    filterConditions.push(this._buildVisibilityQueryPart(requestingUserId));
 
-    // Search keyword conditions using regex
-    if (searchKeyword && searchKeyword.trim().length > 0) { // Ensure searchKeyword is not empty
-      const regex = new RegExp(searchKeyword.trim().replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&'), 'i'); // 'i' for case-insensitive
-      filterConditions.push({
-        $or: [
-          { title: { $regex: regex } },
-          { description: { $regex: regex } },
-        ],
-      });
+    if (searchKeyword && searchKeyword.trim().length > 0) {
+      filterConditions.push(this._buildSearchQueryPart(searchKeyword));
     }
 
     if (filterConditions.length > 0) {
       query.$and = filterConditions;
     }
+    return query;
+  }
 
-    // this.logger.debug(`getCheeksPaginated - MongoDB query: ${JSON.stringify(query)}`); // Log constructed query
-
-    const skip = (page - 1) * limit;
-
-    sortOptionsCreatedAt
-
-    const [cheeksResults, totalItems] = await Promise.all([
-      this.CheeksModel.find(query)
-        .select('-links')
-        .populate(this.cheekListPopulationPaths)
-        .sort(sortOptionsCreatedAt)
-        .skip(skip)
-        .limit(limit)
-        .lean()
-        .exec(),
-      this.CheeksModel.countDocuments(query).exec(),
-    ]);
-
-    const cheekIds = cheeksResults.map(c => c._id as Types.ObjectId); // _id is available on lean objects
-    const reviewStatsMap = await this._getReviewStatsForCheeks(cheekIds);
-
-    const cheeksWithStats = cheeksResults.map(cheek => { // cheek is now a plain object
-      const stats = reviewStatsMap.get((cheek._id as Types.ObjectId).toString());
+  /**
+   * Build the visibility part of the query.
+   */
+  private _buildVisibilityQueryPart(requestingUserId?: string): FilterQuery<CheeksDocument> {
+    if (requestingUserId) {
       return {
-        ...cheek, // Spread the plain cheek object
-        averageRating: stats?.averageRating ?? 0,
-        reviewCount: stats?.reviewCount ?? 0,
-      } as unknown as CheeksDocument; // Future Change:Ideally use a DTO for response
-    });
+        $or: [
+          { isPublic: true },
+          { owner: new Types.ObjectId(requestingUserId) },
+        ],
+      };
+    } else {
+      return { isPublic: true };
+    }
+  }
 
-    return { cheeks: cheeksWithStats, totalItems };
+  /**
+   * Build the search part of the query.
+   */
+  private _buildSearchQueryPart(searchKeyword: string): FilterQuery<CheeksDocument> {
+    const regex = new RegExp(searchKeyword.trim().replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&'), 'i');
+    return {
+      $or: [
+        { title: { $regex: regex } },
+        { description: { $regex: regex } },
+      ],
+    };
+  }
+
+  /**
+   * Build the sort options for cheeks query.
+   */
+  private _buildCheeksSortOptions(sortBy?: string): Record<string, 1 | -1> {
+    switch (sortBy) {
+      case 'oldest':
+        return { createdAt: 1 };
+      case 'rating':
+        return { averageRating: -1, createdAt: -1 };
+      case 'reviewCount':
+        return { reviewCount: -1, createdAt: -1 };
+      case 'alpha':
+        return { title: 1, createdAt: -1 };
+      case 'alphaDesc':
+        return { title: -1, createdAt: -1 };
+      case 'recent':
+        return { createdAt: -1 };
+      default:
+        return { createdAt: -1 };
+    }
   }
 
   async getCheekSuggestions(queryDto?: QueryCheeksDto, requestingUserId?: string): Promise<CheeksDocument[]> {
@@ -561,5 +591,15 @@ export class CheeksService {
       }
     }
     return uniqueSlug;
+  }
+
+  // Recalculate and update averageRating and reviewCount for a cheek
+  async recalculateAndUpdateCheekStats(cheekId: Types.ObjectId | string): Promise<void> {
+    const id = typeof cheekId === 'string' ? new Types.ObjectId(cheekId) : cheekId;
+    const stats = await this._getReviewStatsForCheek(id);
+    await this.CheeksModel.findByIdAndUpdate(id, {
+      averageRating: stats.averageRating,
+      reviewCount: stats.reviewCount,
+    }).exec();
   }
 }

--- a/server/cheekstash-server/src/cheeks/dto/cheeks.dto.ts
+++ b/server/cheekstash-server/src/cheeks/dto/cheeks.dto.ts
@@ -67,4 +67,24 @@ export class CheeksDto {
   @ValidateNested({ each: true })
   @Type(() => LinkDto)
   links: LinkDto[];
+
+  @ApiProperty({
+    example: 4,
+    description: 'Average rating for this cheek, precomputed from reviews',
+    required: false,
+    default: 0,
+  })
+  @IsNumber()
+  @IsOptional()
+  averageRating?: number;
+
+  @ApiProperty({
+    example: 10,
+    description: 'Number of reviews for this cheek, precomputed',
+    required: false,
+    default: 0,
+  })
+  @IsNumber()
+  @IsOptional()
+  reviewCount?: number;
 }

--- a/server/cheekstash-server/src/cheeks/dto/query-cheeks.dto.ts
+++ b/server/cheekstash-server/src/cheeks/dto/query-cheeks.dto.ts
@@ -68,4 +68,13 @@ export class QueryCheeksDto {
     @IsNumber()
     @Min(1)
     limit?: number;
+
+    @ApiPropertyOptional({
+        description: 'Sort by: recent, rating, alpha, reviewCount, etc.',
+        enum: ['recent', 'oldest', 'rating', 'reviewCount', 'alpha', 'alphaDesc'],
+        default: 'recent',
+    })
+    @IsOptional()
+    @IsString()
+    sortBy?: 'recent' | 'oldest' | 'rating' | 'reviewCount' | 'alpha' | 'alphaDesc';
 }

--- a/server/cheekstash-server/src/cheeks/schemas/cheek.schema.ts
+++ b/server/cheekstash-server/src/cheeks/schemas/cheek.schema.ts
@@ -43,6 +43,12 @@ export class Cheeks {
     description?: string;
     order: number;
   }[];
+
+  @Prop({ default: 0 })
+  averageRating: number;
+
+  @Prop({ default: 0 })
+  reviewCount: number;
 }
 
 export const CheeksSchema = SchemaFactory.createForClass(Cheeks);

--- a/server/cheekstash-server/src/reviews/reviews.service.spec.ts
+++ b/server/cheekstash-server/src/reviews/reviews.service.spec.ts
@@ -22,6 +22,7 @@ const mockCheeksService = {
     getCheeksById: jest.fn(),
     findCheekOwnerAndVisibility: jest.fn(),
     findCheekByUsernameAndSlug: jest.fn(),
+    recalculateAndUpdateCheekStats: jest.fn(),
 };
 const mockUsersService = {};
 
@@ -67,6 +68,7 @@ describe('ReviewsService', () => {
         const validUserId = '507f1f77bcf86cd799439013';
         it('should create and return a review', async () => {
             cheeksService.getCheeksById.mockResolvedValue({ _id: validCheekId, owner: 'otherUser' });
+            cheeksService.recalculateAndUpdateCheekStats.mockResolvedValue(undefined); // <-- mock stat update
             model.findOne.mockResolvedValue(null);
             model.mockImplementationOnce(() => ({
                 save: jest.fn().mockResolvedValue({ _id: validReviewId }),
@@ -88,6 +90,7 @@ describe('ReviewsService', () => {
             const result = await service.createReview(dto as any, validUserId, 'user');
             expect(result.rating).toBe(5);
             expect(result.review).toBe('Great!');
+            expect(cheeksService.recalculateAndUpdateCheekStats).toHaveBeenCalledWith(validCheekId);
         });
         it('should throw ForbiddenException if reviewing own cheek', async () => {
             cheeksService.getCheeksById.mockResolvedValue({ _id: validCheekId, owner: validUserId });
@@ -178,6 +181,7 @@ describe('ReviewsService', () => {
         const validUserId = '507f1f77bcf86cd799439013';
         it('should update and return the review', async () => {
             const review = mockReview({ _id: validReviewId, userId: validUserId });
+            cheeksService.recalculateAndUpdateCheekStats.mockResolvedValue(undefined);
             model.findOne.mockResolvedValue(review);
             review.save = jest.fn().mockResolvedValue({ ...review, review: 'Updated' });
             model.findById.mockReturnValue({
@@ -187,6 +191,7 @@ describe('ReviewsService', () => {
             });
             const result = await service.updateReview(validReviewId, { review: 'Updated' }, validUserId);
             expect(result.review).toBe('Updated');
+            expect(cheeksService.recalculateAndUpdateCheekStats).toHaveBeenCalledWith(review.cheekId);
         });
         it('should throw NotFoundException if not found', async () => {
             model.findOne.mockResolvedValue(null);
@@ -198,9 +203,14 @@ describe('ReviewsService', () => {
         const validReviewId = '507f1f77bcf86cd799439012';
         const validUserId = '507f1f77bcf86cd799439013';
         it('should delete and return message', async () => {
+            // Add a mock for cheeksService.recalculateAndUpdateCheekStats
+            cheeksService.recalculateAndUpdateCheekStats.mockResolvedValue(undefined);
+            // Mock reviewToDelete
+            model.findOne.mockResolvedValue({ _id: validReviewId, userId: validUserId, cheekId: 'cheekId' });
             model.deleteOne.mockReturnValue({ exec: jest.fn().mockResolvedValue({ deletedCount: 1 }) });
             const result = await service.deleteReview(validReviewId, validUserId);
             expect(result).toEqual({ message: 'Review deleted successfully' });
+            expect(cheeksService.recalculateAndUpdateCheekStats).toHaveBeenCalledWith('cheekId');
         });
         it('should throw NotFoundException if not found', async () => {
             model.deleteOne.mockReturnValue({ exec: jest.fn().mockResolvedValue({ deletedCount: 0 }) });

--- a/server/cheekstash-server/src/reviews/reviews.service.ts
+++ b/server/cheekstash-server/src/reviews/reviews.service.ts
@@ -91,6 +91,7 @@ export class ReviewsService {
         username, // Storing denormalized username
       });
       const savedReviewDoc = await newReview.save();
+      await this.cheeksService.recalculateAndUpdateCheekStats(createReviewDto.cheekId);
 
       const populatedReview = await this.reviewModel
         .findById(savedReviewDoc._id)
@@ -326,6 +327,7 @@ export class ReviewsService {
     // Apply updates
     Object.assign(reviewToUpdate, updateReviewDto);
     const updatedReviewDoc = await reviewToUpdate.save();
+    await this.cheeksService.recalculateAndUpdateCheekStats(reviewToUpdate.cheekId);
 
     // Populate and transform
     const populatedReview = await this.reviewModel
@@ -350,6 +352,20 @@ export class ReviewsService {
   async deleteReview(reviewId: string, userId: string): Promise<{ message: string }> {
     this._validateObjectId(reviewId, 'Review');
 
+    // Find the review to get the cheekId before deletion
+    const reviewToDelete = await this.reviewModel.findOne({
+      _id: new Types.ObjectId(reviewId),
+      userId: new Types.ObjectId(userId)
+    });
+
+    if (!reviewToDelete) {
+      throw new NotFoundException(
+        `Review with ID \"${reviewId}\" not found or you do not have permission to delete it.`,
+      );
+    }
+
+    const cheekId = reviewToDelete.cheekId;
+
     const deleteResult = await this.reviewModel.deleteOne(
       { _id: new Types.ObjectId(reviewId), userId: new Types.ObjectId(userId) }
     ).exec();
@@ -359,6 +375,7 @@ export class ReviewsService {
         `Review with ID \"${reviewId}\" not found or you do not have permission to delete it.`,
       );
     }
+    await this.cheeksService.recalculateAndUpdateCheekStats(cheekId);
 
     return { message: 'Review deleted successfully' };
   }

--- a/server/cheekstash-server/test/integration/cheeks.integration-spec.ts
+++ b/server/cheekstash-server/test/integration/cheeks.integration-spec.ts
@@ -42,6 +42,11 @@ describe('CheeksController (Integration)', () => {
         // Clear categories collection to avoid duplicates
         const categoryModel = app.get(getModelToken('Category'));
         await categoryModel.deleteMany({});
+        // Clear cheeks and tags collections to ensure test isolation
+        const cheeksModel = app.get(getModelToken('Cheeks'));
+        await cheeksModel.deleteMany({});
+        const tagModel = app.get(getModelToken('Tag'));
+        await tagModel.deleteMany({});
 
         // Register a user
         await request(httpServer).post('/api/users/register').send(userDto);
@@ -205,6 +210,77 @@ describe('CheeksController (Integration)', () => {
                 .delete(`/api/cheeks/${id}`)
                 .set('Authorization', `Bearer ${token}`);
             expect(res.status).toBe(200);
+        });
+    });
+
+    describe('GET /api/cheeks (sorting, pagination, filtering)', () => {
+        let createdCheeks: any[] = [];
+        beforeEach(async () => {
+            // Create multiple cheeks with different titles, ratings, and reviewCounts
+            createdCheeks = [];
+            for (let i = 0; i < 5; i++) {
+                const cheekRes = await request(httpServer)
+                    .post('/api/cheeks')
+                    .set('Authorization', `Bearer ${token}`)
+                    .send({
+                        ...currentCheekDto,
+                        title: `Cheek${i}`,
+                        isPublic: true,
+                        tagNames: [`tag${i}`],
+                    });
+                createdCheeks.push(cheekRes.body);
+            }
+        });
+        it('should sort by recent (default)', async () => {
+            const res = await request(httpServer).get('/api/cheeks');
+            expect(res.status).toBe(200);
+            expect(res.body.cheeks.length).toBeGreaterThan(0);
+            // Most recent first
+            expect(res.body.cheeks[0].title).toContain('Cheek');
+        });
+        it('should sort by oldest', async () => {
+            const res = await request(httpServer).get('/api/cheeks?sortBy=oldest');
+            expect(res.status).toBe(200);
+            expect(res.body.cheeks.length).toBeGreaterThan(0);
+            // Oldest first
+            expect(res.body.cheeks[0].title).toBe('Cheek0');
+        });
+        it('should sort by alpha', async () => {
+            const res = await request(httpServer).get('/api/cheeks?sortBy=alpha');
+            expect(res.status).toBe(200);
+            const titles = res.body.cheeks.map((c: any) => c.title);
+            const sorted = [...titles].sort();
+            expect(titles).toEqual(sorted);
+        });
+        it('should sort by alphaDesc', async () => {
+            const res = await request(httpServer).get('/api/cheeks?sortBy=alphaDesc');
+            expect(res.status).toBe(200);
+            const titles = res.body.cheeks.map((c: any) => c.title);
+            const sorted = [...titles].sort().reverse();
+            expect(titles).toEqual(sorted);
+        });
+        it('should support pagination', async () => {
+            const res = await request(httpServer).get('/api/cheeks?page=2&limit=2');
+            expect(res.status).toBe(200);
+            expect(res.body.cheeks.length).toBeLessThanOrEqual(2);
+        });
+        it('should filter by categoryId', async () => {
+            // categoryId may be an object, so extract _id if needed
+            const rawCategoryId = createdCheeks[0].categoryId;
+            const categoryId = typeof rawCategoryId === 'object' && rawCategoryId !== null && '_id' in rawCategoryId ? rawCategoryId._id : rawCategoryId;
+            const res = await request(httpServer).get(`/api/cheeks?categoryIds=${categoryId}`);
+            expect(res.status).toBe(200);
+            // Compare c.categoryId._id to categoryId
+            expect(res.body.cheeks.every((c: any) => c.categoryId && c.categoryId._id && c.categoryId._id.toString() === categoryId.toString())).toBe(true);
+        });
+        it('should filter by tagId', async () => {
+            // tagId may be an object, so extract _id if needed
+            const rawTagId = createdCheeks[0].tagIds[0];
+            const tagId = typeof rawTagId === 'object' && rawTagId !== null && '_id' in rawTagId ? rawTagId._id : rawTagId;
+            const res = await request(httpServer).get(`/api/cheeks?tagIds=${tagId}`);
+            expect(res.status).toBe(200);
+            // Compare each tag's _id to tagId
+            expect(res.body.cheeks.every((c: any) => Array.isArray(c.tagIds) && c.tagIds.some((t: any) => t && t._id && t._id.toString() === tagId.toString()))).toBe(true);
         });
     });
 });

--- a/server/cheekstash-server/test/integration/reviews.integration-spec.ts
+++ b/server/cheekstash-server/test/integration/reviews.integration-spec.ts
@@ -69,7 +69,7 @@ describe('ReviewsController (Integration)', () => {
     });
 
     describe('POST /api/reviews', () => {
-        it('should create a review for a cheek by a non-owner', async () => {
+        it('should create a review for a cheek by a non-owner and update cheek stats', async () => {
             const dto = { cheekId: cheek._id.toString(), rating: 4, review: 'Great cheek!' };
             const res = await request(httpServer)
                 .post('/api/reviews')
@@ -80,6 +80,9 @@ describe('ReviewsController (Integration)', () => {
             expect(res.body.rating).toBe(4);
             expect(res.body.review).toBe('Great cheek!');
             expect(res.body.user.username).toBe(user.username);
+            const updatedCheek = await cheekModel.findById(cheek._id).lean();
+            expect(updatedCheek && updatedCheek.averageRating).toBe(4);
+            expect(updatedCheek && updatedCheek.reviewCount).toBe(1);
         });
         it('should not allow the owner to review their own cheek', async () => {
             const dto = { cheekId: cheek._id.toString(), rating: 5, review: 'My own cheek' };
@@ -174,7 +177,7 @@ describe('ReviewsController (Integration)', () => {
     });
 
     describe('PUT /api/reviews/:reviewId', () => {
-        it('should update a review by owner', async () => {
+        it('should update a review by owner and update cheek stats', async () => {
             const review = await reviewModel.create({ cheekId: cheek._id, userId: user._id, username: user.username, rating: 3, review: 'Old', createdAt: new Date(), updatedAt: new Date() });
             const dto = { rating: 5, review: 'Updated!' };
             const res = await request(httpServer)
@@ -184,6 +187,9 @@ describe('ReviewsController (Integration)', () => {
             expect(res.status).toBe(200);
             expect(res.body.rating).toBe(5);
             expect(res.body.review).toBe('Updated!');
+            const updatedCheek = await cheekModel.findById(cheek._id).lean();
+            expect(updatedCheek && updatedCheek.averageRating).toBe(5);
+            expect(updatedCheek && updatedCheek.reviewCount).toBe(1);
         });
         it('should not allow non-owner to update', async () => {
             const review = await reviewModel.create({ cheekId: cheek._id, userId: user._id, username: user.username, rating: 3, review: 'Old', createdAt: new Date(), updatedAt: new Date() });
@@ -197,13 +203,16 @@ describe('ReviewsController (Integration)', () => {
     });
 
     describe('DELETE /api/reviews/:reviewId', () => {
-        it('should delete a review by owner', async () => {
+        it('should delete a review by owner and update cheek stats', async () => {
             const review = await reviewModel.create({ cheekId: cheek._id, userId: user._id, username: user.username, rating: 3, review: 'To delete', createdAt: new Date(), updatedAt: new Date() });
             const res = await request(httpServer)
                 .delete(`/api/reviews/${review._id}`)
                 .set('Authorization', `Bearer ${userToken}`);
             expect(res.status).toBe(200);
             expect(res.body.message).toMatch(/deleted/i);
+            const updatedCheek = await cheekModel.findById(cheek._id).lean();
+            expect(updatedCheek && updatedCheek.averageRating).toBe(0);
+            expect(updatedCheek && updatedCheek.reviewCount).toBe(0);
         });
         it('should not allow non-owner to delete', async () => {
             const review = await reviewModel.create({ cheekId: cheek._id, userId: user._id, username: user.username, rating: 3, review: 'To delete', createdAt: new Date(), updatedAt: new Date() });


### PR DESCRIPTION
Unit and Integration tests have been updated accordingly and ALL PASS.

NOTE:
Previously the sorting was purely done through the client side, meaning that only the retrieved Cheeks would sort. New changes introduce server side sorting.

An addition that allows for this implementation is the inclusion of a precomputed average rating and rating count on the cheek collection. Respective methods have been revised to ensure up to date values for those properties.